### PR TITLE
Add `safe.directory` to render all action

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -52,13 +52,14 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
       - name: Login as jhudsl-robot
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
 


### PR DESCRIPTION
Institutes a quick patch building off of #11 that will hopefully fix the "can only be used inside a git repository" error. Previously this bit of code was just in `pull-request`